### PR TITLE
add warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# Warning
+**This contract is under development and is unsafe to use in its current form. Check back soon**
+
 # ModGuard
 
 [![Build Status](https://github.com/gnosis/zodiac-guard-mod/actions/workflows/ci.yml/badge.svg)](https://github.com/gnosis/zodiac-guard-mod/actions/workflows/ci.yml)


### PR DESCRIPTION
## Fix a bug

### Implementation

This PR adds a big warning to the top of the repo letting users know that the contract is under development and is unsafe to use in its current form.